### PR TITLE
Use setvbuf and allocate a heap buffer on file access

### DIFF
--- a/RSDKv5/RSDK/Core/Reader.cpp
+++ b/RSDKv5/RSDK/Core/Reader.cpp
@@ -203,6 +203,9 @@ bool32 RSDK::OpenDataFile(FileInfo *info, const char *filename)
                 return false;
             }
 
+            if (!info->iocache)
+              info->iocache = (uint8*)malloc(file->size);
+            setvbuf(info->file, (char*)info->iocache, _IOFBF, file->size);
             fSeek(info->file, file->offset, SEEK_SET);
         }
         else {

--- a/RSDKv5/RSDK/Core/Reader.hpp
+++ b/RSDKv5/RSDK/Core/Reader.hpp
@@ -48,6 +48,7 @@ struct FileInfo {
     int32 externalFile;
     FileIO *file;
     uint8 *fileBuffer;
+    uint8 *iocache;
     int32 readPos;
     int32 fileOffset;
     uint8 usingFileBuffer;
@@ -111,6 +112,7 @@ inline void InitFileInfo(FileInfo *info)
     info->encrypted       = false;
     info->readPos         = 0;
     info->fileOffset      = 0;
+    info->iocache         = NULL;
 }
 
 bool32 LoadFile(FileInfo *info, const char *filename, uint8 fileMode);
@@ -121,6 +123,10 @@ inline void CloseFile(FileInfo *info)
         fClose(info->file);
 
     info->file = NULL;
+    if (info->iocache) {
+        free(info->iocache);
+        info->iocache = NULL;
+    }
 }
 
 void GenerateELoadKeys(FileInfo *info, const char *key1, int32 key2);


### PR DESCRIPTION
This works around the default 1KB buffer that 3DS newlib has, which makes I/O slow. With this "hack" I mean, workaround, load times are reduced to 25% (around 3-4x faster), making the experience enjoyable. Level loading times around around 4-6 seconds (vs ~25s).

This is a hack, ideally some intermediate loading method should be added for consoles that do not have enough ram to load the entire datapack but have enough memory to load a significant amount of it (i.e. an LRU buffer cache or something).